### PR TITLE
parse runc-version, not go.mod (vendor.conf)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,8 @@ jobs:
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
           VERSION=$(git describe --match 'v[0-9]*' --dirty='.m' --always)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          if [ -f go.mod ]; then
-            RUNC_COMMIT=$(grep opencontainers/runc go.mod | awk '{print $2}')
-          else
-            # containerd 1.4 and lower use vendor.conf for the modules
-            RUNC_COMMIT=$(grep opencontainers/runc vendor.conf | awk '{print $2}')
-          fi
+          # script/setup/runc-version was introduced in containerd v1.5.0 / v1.4.5 .
+          RUNC_COMMIT=$(cat script/setup/runc-version)
           echo "RUNC_COMMIT=${RUNC_COMMIT}" >> $GITHUB_ENV
           GO_VERSION=$(grep go_version .zuul/playbooks/containerd-build/run.yaml | grep -Eo [0-9]\.[0-9]+\.[^\']+)
           echo "GO_VERSION=${GO_VERSION}" >> $GITHUB_ENV


### PR DESCRIPTION
The previous version detecton was not correct, as the runc binary
version may differ from runc library version.

The new logic is to parse `script/setup/runc-version` file.

This file was introduced in containerd v1.5.0 and backported to v1.4.5.

https://github.com/containerd/containerd/blob/v1.4.5/script/setup/runc-version
https://github.com/containerd/containerd/blob/v1.5.1/script/setup/runc-version

- - -
Fix #19 