### PR TITLE
Add `runc.VERSION` to the release artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,12 @@ jobs:
             libbtrfs-dev:s390x \
             libbtrfs-dev:ppc64el
 
+      - name: Create runc.VERSION
+        working-directory: src/github.com/containerd/containerd
+        run: |
+          set -x
+          echo "${RUNC_VERSION}" > releases/runc.VERSION
+
       - name: Build amd64
         env:
           GOOS: linux


### PR DESCRIPTION
Previously, the version of runc binary was not detectable
without reading the yaml or executing the actual binary.
